### PR TITLE
HTML 5 compatibility fixes

### DIFF
--- a/templates/card.html
+++ b/templates/card.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="assets/css/stylesheet.css" />
 </head>
@@ -15,6 +19,6 @@
 			Create a Greeting Card
 		</a>
 	</div>
-	<footer>Created by <a href="http://www.github.com/ryanmurakami">Ryan Lewis</a> & friends</footer>
+	<footer>Created by <a href="http://www.github.com/ryanmurakami">Ryan Lewis</a> &amp; friends</footer>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/new.html
+++ b/templates/new.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,5 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
+	<meta charset="utf-8">
+	<meta http-equiv="x-ua-compatible" content="ie=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>hapi Greetings</title>
 	<link rel="stylesheet" href="/assets/css/stylesheet.css" />
 </head>


### PR DESCRIPTION
- Added HTML5 DOCTYPE tags and meta tags in all but `email.html` (which I am assuming is intentionally an HTML fragment).  The DOCTYPE combined with the `x-ua-compatible` meta tag is required to get the pages to render correctly in IE in corporate environments (like mine, and I'm assuming other PS customers) that assume quirks mode should be the default on intranet sites (which includes localhost) unless these tags are present.
- Also fixed un-escaped ampersand in index.html.

**Warning:** this may cause inconsistencies with line numbers such as in clip 6 of module 3 at :25 seconds where you say "around line 31" and now it's around line 35.  (Hopefully any developer for whom your course is appropriate will be able to work around this).
